### PR TITLE
Handle blockhash string terminator

### DIFF
--- a/esplora.c
+++ b/esplora.c
@@ -232,11 +232,15 @@ static struct command_result *getrawblockbyheight(struct command *cmd,
   // fetch blockhash from block height
   const char *blockhash_url =
       tal_fmt(cmd->plugin, "%s/block-height/%d", endpoint, *height);
-  const char *blockhash = request_get(cmd, blockhash_url);
-  if (!blockhash) {
+  const char *blockhash_ = request_get(cmd, blockhash_url);
+  if (!blockhash_) {
     // block not found as getrawblockbyheight_notfound
     return getrawblockbyheight_notfound(cmd);
   }
+  char *blockhash =
+      tal_dup_arr(cmd, char, (char *)blockhash_, tal_count(blockhash_), 1);
+  blockhash[tal_count(blockhash_)] = '\0';
+  tal_free(blockhash_);
   plugin_log(cmd->plugin, LOG_INFORM, "blockhash: %s from %s", blockhash,
              blockhash_url);
 


### PR DESCRIPTION
Add a '\0' to blockhash char array before using as a string.

Close https://github.com/lvaccaro/esplora_clnd_plugin/issues/22