### PR TITLE
Validate getutxout inputs

### DIFF
--- a/esplora.c
+++ b/esplora.c
@@ -356,7 +356,8 @@ static struct command_result *getutxout(struct command *cmd, const char *buf,
   struct bitcoin_tx_output output;
   bool valid = false;
 
-  plugin_log(cmd->plugin, LOG_INFORM, "getutxout");
+  if (!param(cmd, buf, toks, NULL))
+    return command_param_failed();
 
   /* bitcoin-cli wants strings. */
   if (!param(cmd, buf, toks, p_req("txid", param_string, &txid),
@@ -371,6 +372,9 @@ static struct command_result *getutxout(struct command *cmd, const char *buf,
         cmd, "Conversion error occurred on %s (error: %s)", vout, error);
     return command_done_err(cmd, BCLI_ERROR, err, NULL);
   }
+
+  plugin_log(cmd->plugin, LOG_INFORM, "getutxout: txid %s - vout %d", txid,
+             vout_index);
 
   // check transaction output is spent
   const char *status_url =


### PR DESCRIPTION
Validate inputs for getutxout to interrupt execution with bad inputs.

In `libplugin.c` `plugin_main()`, `setup_command_usage()` calls the plugin handle for each commands. So the pugin need to validate the input to avoid crashes.

Close https://github.com/lvaccaro/esplora_clnd_plugin/issues/24