### PR TITLE
Curl: retry requests to the endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ sed -i 's/LDLIBS = /LDLIBS = -lcurl -lssl -lcrypto /g' Makefile
 #### Run
 Disable `bcli` plugin in order to fetch bitcoin data from `esplora` plugin, and set plugin options, as the following:
 ```
-lightningd --testnet --disable-plugin bcli --log-level=debug \
+./lightningd/lightningd --testnet --disable-plugin bcli --log-level=debug \
  --esplora-api-endpoint=https://blockstream.info/testnet/api
 ```
 

--- a/esplora.c
+++ b/esplora.c
@@ -76,44 +76,45 @@ static size_t write_memory_callback(void *contents, size_t size, size_t nmemb,
 
 static u8 *request(const tal_t *ctx, const char *url, const bool post,
                    const char *data) {
-  struct curl_memory_data chunk;
-  chunk.memory = tal_arr(ctx, u8, 64);
-  chunk.size = 0;
+	long response_code;
+	struct curl_memory_data chunk;
+	chunk.memory = tal_arr(ctx, u8, 64);
+	chunk.size = 0;
 
-  CURL *curl;
-  CURLcode res;
-  curl = curl_easy_init();
-  if (!curl) {
-    return NULL;
-  }
-  curl_easy_setopt(curl, CURLOPT_URL, url);
-  curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
-  curl_easy_setopt(curl, CURLOPT_ACCEPT_ENCODING, "gzip");
-  if (verbose != 0)
-    curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
-  if (cainfo_path != NULL)
-    curl_easy_setopt(curl, CURLOPT_CAINFO, cainfo_path);
-  if (capath != NULL)
-    curl_easy_setopt(curl, CURLOPT_CAPATH, capath);
-  if (post) {
-    curl_easy_setopt(curl, CURLOPT_POST, 1L);
-    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, data);
-  }
-  curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)&chunk);
-  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_memory_callback);
+	CURL *curl;
+	CURLcode res;
+	curl = curl_easy_init();
+	if (!curl) {
+		return NULL;
+	}
 
-  res = curl_easy_perform(curl);
-  if (res != CURLE_OK) {
-    return tal_free(chunk.memory);
-  }
-  long response_code;
-  curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
-  if (response_code != 200) {
-    return tal_free(chunk.memory);
-  }
-  curl_easy_cleanup(curl);
-  tal_resize(&chunk.memory, chunk.size);
-  return chunk.memory;
+	curl_easy_setopt(curl, CURLOPT_URL, url);
+	curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+	curl_easy_setopt(curl, CURLOPT_ACCEPT_ENCODING, "gzip");
+	if (verbose != 0)
+		curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+	if (cainfo_path != NULL)
+		curl_easy_setopt(curl, CURLOPT_CAINFO, cainfo_path);
+	if (capath != NULL)
+		curl_easy_setopt(curl, CURLOPT_CAPATH, capath);
+	if (post) {
+		curl_easy_setopt(curl, CURLOPT_POST, 1L);
+		curl_easy_setopt(curl, CURLOPT_POSTFIELDS, data);
+	}
+	curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)&chunk);
+	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_memory_callback);
+
+	res = curl_easy_perform(curl);
+	if (res != CURLE_OK)
+		return tal_free(chunk.memory);
+	curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
+	if (response_code != 200)
+		return tal_free(chunk.memory);
+
+	curl_easy_cleanup(curl);
+	tal_resize(&chunk.memory, chunk.size);
+
+	return chunk.memory;
 }
 
 static char *request_get(const tal_t *ctx, const char *url) {

--- a/esplora.c
+++ b/esplora.c
@@ -584,7 +584,7 @@ int main(int argc, char *argv[]) {
 		    plugin_option("esplora-verbose", "bool",
 				  "Set verbose output (default: false).",
 				  bool_option, &esplora->verbose),
-		    plugin_option("esplora-retries", "int",
+		    plugin_option("esplora-retries", "string",
 				  "How many times should we retry a request to the"
 				  "endpoint before dying ?", u32_option, &esplora->n_retries),
 		    NULL);

--- a/esplora.c
+++ b/esplora.c
@@ -29,9 +29,8 @@ struct esplora {
 	char *cainfo_path;
 	char *capath;
 
-	/* Make curl request more verbose.
-	 * FIXME: this should be a bool! */
-	u64 verbose;
+	/* Make curl request more verbose. */
+	bool verbose;
 
 	/* How many times do we retry curl requests ? */
 	u32 n_retries;
@@ -119,7 +118,7 @@ static u8 *request(const tal_t *ctx, const char *url, const bool post,
 	curl_easy_setopt(curl, CURLOPT_URL, url);
 	curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
 	curl_easy_setopt(curl, CURLOPT_ACCEPT_ENCODING, "gzip");
-	if (esplora->verbose != 0)
+	if (esplora->verbose)
 		curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 	if (esplora->cainfo_path != NULL)
 		curl_easy_setopt(curl, CURLOPT_CAINFO, esplora->cainfo_path);
@@ -542,7 +541,7 @@ static struct esplora *new_esplora(const tal_t *ctx)
 	esplora->endpoint = NULL;
 	esplora->capath = NULL;
 	esplora->cainfo_path = NULL;
-	esplora->verbose = 0;
+	esplora->verbose = false;
 	esplora->n_retries = 4;
 
 	return esplora;
@@ -582,8 +581,8 @@ int main(int argc, char *argv[]) {
               plugin_option("esplora-capath", "string",
                             "Specify directory holding CA certificates.",
                             charp_option, &esplora->capath),
-              plugin_option("esplora-verbose", "int",
-                            "Set verbose output (default 0).", u64_option,
+              plugin_option("esplora-verbose", "bool",
+                            "Set verbose output (default: false).", bool_option,
                             &esplora->verbose),
 	      plugin_option("esplora-retries", "int",
 		      "How many times should we retry a request to the"

--- a/esplora.c
+++ b/esplora.c
@@ -564,28 +564,28 @@ static const struct plugin_command commands[] = {
 };
 
 int main(int argc, char *argv[]) {
-  setup_locale();
+	setup_locale();
 
 	/* Our global state. */
 	esplora = new_esplora(NULL);
 
-  plugin_main(argv, init, PLUGIN_STATIC, false, NULL, commands,
-              ARRAY_SIZE(commands), NULL, 0, NULL, 0,
-              plugin_option(
-                  "esplora-api-endpoint", "string",
-                  "The URL of the esplora instance to hit (including '/api').",
-                  charp_option, &esplora->endpoint),
-              plugin_option("esplora-cainfo", "string",
-                            "Set path to Certificate Authority (CA) bundle.",
-                            charp_option, &esplora->cainfo_path),
-              plugin_option("esplora-capath", "string",
-                            "Specify directory holding CA certificates.",
-                            charp_option, &esplora->capath),
-              plugin_option("esplora-verbose", "bool",
-                            "Set verbose output (default: false).", bool_option,
-                            &esplora->verbose),
-	      plugin_option("esplora-retries", "int",
-		      "How many times should we retry a request to the"
-		      "endpoint before dying ?", u32_option, &esplora->n_retries),
-              NULL);
+	plugin_main(argv, init, PLUGIN_STATIC, false, NULL, commands,
+		    ARRAY_SIZE(commands), NULL, 0, NULL, 0,
+		    plugin_option("esplora-api-endpoint", "string",
+				  "The URL of the esplora instance to hit "
+				  "(including '/api').",
+				  charp_option, &esplora->endpoint),
+		    plugin_option("esplora-cainfo", "string",
+				  "Set path to Certificate Authority (CA) bundle.",
+				  charp_option, &esplora->cainfo_path),
+		    plugin_option("esplora-capath", "string",
+				  "Specify directory holding CA certificates.",
+				  charp_option, &esplora->capath),
+		    plugin_option("esplora-verbose", "bool",
+				  "Set verbose output (default: false).",
+				  bool_option, &esplora->verbose),
+		    plugin_option("esplora-retries", "int",
+				  "How many times should we retry a request to the"
+				  "endpoint before dying ?", u32_option, &esplora->n_retries),
+		    NULL);
 }


### PR DESCRIPTION
This is an alternative to #26 (closes #26), in order to fix #16.

Turns out i made a few other drive-by changes, but i think it was worth it :).

Summary:
- we now retry curl request multiple times (4 by default)
- new startup option `esplora-retries` which conditions how many times we'll retry a request.
- the startup option `verbose` now takes a boolean (breaking change!)
- small cleanups here and there.