### PR TITLE
esplora: use tal_hex() in getutxout

### DIFF
--- a/esplora.c
+++ b/esplora.c
@@ -462,8 +462,7 @@ static struct command_result *getutxout(struct command *cmd, const char *buf,
   // replay response
   response = jsonrpc_stream_success(cmd);
   json_add_amount_sat_only(response, "amount", output.amount);
-  json_add_string(response, "script",
-                  tal_hexstr(response, output.script, sizeof(output.script)));
+  json_add_string(response, "script", tal_hex(response, output.script));
 
   return command_finished(cmd, response);
 }


### PR DESCRIPTION
A patch i proposed in https://github.com/lvaccaro/esplora_clnd_plugin/issues/15#issuecomment-683446999, this might not fix it but it's good to have this nonetheless :)