### PR TITLE
Add python3 virtual env on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
   - sudo apt-get -q update
   - sudo apt-get -y install autoconf automake build-essential git libtool libgmp-dev libsqlite3-dev python3 python3-mako net-tools zlib1g-dev libsodium-dev gettext
   - sudo apt-get install -y valgrind python3-pip libpq-dev
-  - sudo apt-get install -y python3-setuptools libcurl4-openssl-dev libssl-dev clang-format-3.8
+  - sudo apt-get install -y python3-setuptools python3-virtualenv libcurl4-openssl-dev libssl-dev clang-format-3.8
 
 before_script:
   - clang-format -i *.c && git diff --exit-code
@@ -16,10 +16,13 @@ script:
   - git clone https://github.com/ElementsProject/lightning.git
   - cd lightning
   - git checkout v0.9.0-1
-  - pip3 install -r requirements.txt
+  - python3 -m virtualenv venv
+  - source venv/bin/activate
+  - pip install -r requirements.txt
   - cp ../esplora.* plugins/
   - patch -p1 < ../Makefile.patch
   - sed -i 's/PLUGINS=/PLUGINS=plugins\/esplora /g' Makefile
   - sed -i 's/LDLIBS = /LDLIBS = -lcurl -lssl -lcrypto /g' Makefile
   - ./configure
   - make
+  - deactivate


### PR DESCRIPTION
Add virtualenv command in order to use a python3 environment and restore travis build